### PR TITLE
fix: dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directories:
       - "/portainer"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "enhancement"
       - "docker-compose"
@@ -16,7 +16,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "enhancement"
       - "github-action"

--- a/portainer/homepage/config/services.yaml
+++ b/portainer/homepage/config/services.yaml
@@ -148,7 +148,7 @@
           - type: audiobookshelf
             url: http://{{HOMEPAGE_VAR_IP}}:13378
             key: {{HOMEPAGE_VAR_ABS_API_KEY}}
-            fields: ["books", "booksDuration","podcasts"]
+            fields: ["books", "booksDuration", "podcasts"]
 
     - Radarr:
         icon: radarr.png


### PR DESCRIPTION
This PR updates the Dependabot configuration to change the update interval from "weekly" to "daily".

    The Dependabot schedule for the /portainer directory is updated to daily.
    The Dependabot schedule for GitHub Actions is also updated to daily.
